### PR TITLE
Blur textarea on escape

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -106,6 +106,13 @@ export function eventHandler(event: KeyboardEvent): void {
 
 		event.preventDefault();
 		event.stopImmediatePropagation();
+	} else if (
+		event.key === 'Escape' &&
+		!event.shiftKey
+	) {
+		textarea.blur();
+
+		event.preventDefault();
 	}
 }
 

--- a/index.ts
+++ b/index.ts
@@ -111,8 +111,8 @@ export function eventHandler(event: KeyboardEvent): void {
 		!event.shiftKey
 	) {
 		textarea.blur();
-
 		event.preventDefault();
+		event.stopImmediatePropagation();
 	}
 }
 

--- a/index.ts
+++ b/index.ts
@@ -86,18 +86,18 @@ export function unindent(element: HTMLTextAreaElement): void {
 }
 
 export function eventHandler(event: KeyboardEvent): void {
-	if (event.defaultPrevented) {
+	if (
+		event.defaultPrevented ||
+		event.metaKey ||
+		event.altKey ||
+		event.ctrlKey
+	) {
 		return;
 	}
 
 	const textarea = event.target as HTMLTextAreaElement;
 
-	if (
-		event.key === 'Tab' &&
-		!event.metaKey &&
-		!event.altKey &&
-		!event.ctrlKey
-	) {
+	if (event.key === 'Tab') {
 		if (event.shiftKey) {
 			unindent(textarea);
 		} else {

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ If you prefer the raw `indent`/`unindent` methods, they're also available below.
 
 ### indentation.watch(textarea)
 
-Adds <kbd>tab</kbd> and <kbd>shift+tab</kbd> event listeners to the provided `textarea`(s).
+Adds <kbd>tab</kbd> and <kbd>shift+tab</kbd> event listeners to the provided `textarea`(s). It also listens to <kbd>esc</kbd> to blur/unfocus the field and allow the user to keep tabbing.
 
 #### textarea
 


### PR DESCRIPTION
Blurs the textarea on keydown for escape when there are no modifier active.

Also moves the checks for undesired modifiers earlier so the check can be shared for both keys.

I did not add any option to opt out of this since there is no conflicting default behaviour, and also because there was no option handling in place already.

Fixes #12