### PR TITLE
Improve API names

### DIFF
--- a/.github/workflows/esm-lint.yml
+++ b/.github/workflows/esm-lint.yml
@@ -1,5 +1,5 @@
 env:
-  IMPORT_TEXT: import {indent} from
+  IMPORT_TEXT: import {enableTabToIndent} from
   NPM_MODULE_NAME: indent-textarea
 
 # FILE GENERATED WITH: npx ghat fregante/ghatemplates/esm-lint

--- a/index.ts
+++ b/index.ts
@@ -6,11 +6,11 @@ import {insert} from 'text-field-edit';
 
 Indent and unindent affect characters outside the selection, so the selection has to be expanded (`newSelection`) before applying the replacement regex.
 
-The `unindent` selection expansion logic is a bit convoluted and I wish a genius would rewrite it more efficiently.
+The unindent selection expansion logic is a bit convoluted and I wish a genius would rewrite it more efficiently.
 
 */
 
-export function indent(element: HTMLTextAreaElement): void {
+export function indentField(element: HTMLTextAreaElement): void {
 	const {selectionStart, selectionEnd, value} = element;
 	const selectedText = value.slice(selectionStart, selectionEnd);
 	// The first line should be indented, even if it starts with `\n`
@@ -53,7 +53,7 @@ function findLineEnd(value: string, currentEnd: number): number {
 
 // The first line should always be unindented
 // The last line should only be unindented if the selection includes any characters after `\n`
-export function unindent(element: HTMLTextAreaElement): void {
+export function unindentField(element: HTMLTextAreaElement): void {
 	const {selectionStart, selectionEnd, value} = element;
 
 	// Select the whole first line because it might contain \t
@@ -85,7 +85,7 @@ export function unindent(element: HTMLTextAreaElement): void {
 	);
 }
 
-export function eventHandler(event: KeyboardEvent): void {
+export function tabToIndentListener(event: KeyboardEvent): void {
 	if (
 		event.defaultPrevented
 		|| event.metaKey
@@ -99,9 +99,9 @@ export function eventHandler(event: KeyboardEvent): void {
 
 	if (event.key === 'Tab') {
 		if (event.shiftKey) {
-			unindent(textarea);
+			unindentField(textarea);
 		} else {
-			indent(textarea);
+			indentField(textarea);
 		}
 
 		event.preventDefault();
@@ -121,7 +121,7 @@ type WatchableElements =
 	| HTMLTextAreaElement
 	| Iterable<HTMLTextAreaElement>;
 
-export function watch(
+export function enableTabToIndent(
 	elements: WatchableElements,
 	signal?: AbortSignal,
 ): void {
@@ -132,15 +132,6 @@ export function watch(
 	}
 
 	for (const element of elements) {
-		element.addEventListener('keydown', eventHandler, {signal});
+		element.addEventListener('keydown', tabToIndentListener, {signal});
 	}
 }
-
-const indentTextarea = {
-	indent,
-	unindent,
-	eventHandler,
-	watch,
-};
-
-export default indentTextarea;

--- a/index.ts
+++ b/index.ts
@@ -135,3 +135,12 @@ export function enableTabToIndent(
 		element.addEventListener('keydown', tabToIndentListener, {signal});
 	}
 }
+
+/** @deprecated Renamed to indentField */
+export const indent = indentField;
+/** @deprecated Renamed to unindentField */
+export const unindent = unindentField;
+/** @deprecated Renamed to tabToIndentListener */
+export const eventHandler = tabToIndentListener;
+/** @deprecated Renamed to enableTabToIndent */
+export const watch = enableTabToIndent;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"scripts": {
 		"build": "tsc",
 		"prepack": "tsc --sourceMap false",
-		"test": "run-s build test:*",
+		"test": "run-s build test:* demo:build",
 		"test:blink": "browserify -p esmify tests/* | tape-run --browser chrome",
 		"test:gecko": "browserify -p esmify tests/* | tape-run --browser firefox",
 		"test:lint": "xo",

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ This only supports <kbd>tab</kbd> and <kbd>shift+tab</kbd> but it doesn't preser
 
 ## Install
 
-You can download the [standalone bundle](https://bundle.fregante.com/?pkg=indent-textarea&global=indentation)
+You can download the [standalone bundle](https://bundle.fregante.com/?pkg=indent-textarea&global=window)
 
 Or use `npm`:
 
@@ -28,7 +28,7 @@ npm install indent-textarea
 
 ```js
 // This module is only offered as a ES Module
-import * as indentation from 'indent-textarea';
+import {enableTabToIndent} from 'indent-textarea';
 ```
 
 ## Usage
@@ -37,23 +37,23 @@ You can listen to <kbd>tab</kbd> and <kbd>shift+tab</kbd> to indent and unindent
 
 ```js
 const textarea = document.querySelector('textarea');
-indentation.watch(textarea);
+enableTabToIndent(textarea);
 ```
 
 If you prefer [event delegation](https://github.com/fregante/delegate-it):
 
 ```js
 import delegate from 'delegate-it';
-import {eventHandler} from 'indent-textarea';
+import {tabToIndentListener} from 'indent-textarea';
 
-delegate(document.body, 'textarea', 'keydown', eventHandler);
+delegate(document.body, 'textarea', 'keydown', tabToIndentListener);
 ```
 
-If you prefer the raw `indent`/`unindent` methods, they're also available below.
+If you prefer the raw `indentField`/`unindentField` methods, they're also available below.
 
 ## API
 
-### indentation.watch(textarea, signal)
+### enableTabToIndent(textarea, signal)
 
 Adds <kbd>tab</kbd> and <kbd>shift+tab</kbd> event listeners to the provided `textarea`(s). It also listens to <kbd>esc</kbd> to blur/unfocus the field and allow the user to keep tabbing.
 
@@ -69,18 +69,18 @@ This can be:
 
 #### signal
 
-This is an `AbortSignal` that allows you to remove the listener (or "unwatch")
+This is an `AbortSignal` that allows you to remove/disable the listener
 
 ```js
 const controller = new AbortController();
 const textarea = document.querySelector('textarea');
-indentation.watch(textarea, controller.signal);
+enableTabToIndent(textarea, controller.signal);
 
 // And then later, to stop listening
 controller.abort();
 ```
 
-### indentation.indent(textarea)
+### indentField(textarea)
 
 Raw method to indent the selected text in the provided `<textarea>` element, once, instantly.
 
@@ -88,7 +88,7 @@ Raw method to indent the selected text in the provided `<textarea>` element, onc
 
 Type: `HTMLTextAreaElement`
 
-### indentation.unindent(textarea)
+### unindentField(textarea)
 
 Raw method to unindent the selected text in the provided `<textarea>` element, once, instantly.
 
@@ -96,23 +96,23 @@ Raw method to unindent the selected text in the provided `<textarea>` element, o
 
 Type: `HTMLTextAreaElement`
 
-### indentation.eventHandler
+### tabToIndentListener
 
 Type: `(event: KeyboardEvent) => void`
 
-Raw event handler used by `indentation.watch` or to use manually via `addEventListener`
+Raw event handler used by `enableTabToIndent` or to use manually via `addEventListener`
 
 ```js
-document.querySelector('textarea').addEventListener('keydown', eventHandler);
+document.querySelector('textarea').addEventListener('keydown', tabToIndentListener);
 ```
 
 Or with [event delegation](https://github.com/fregante/delegate-it):
 
 ```js
 import delegate from 'delegate-it';
-import {eventHandler} from 'indent-textarea';
+import {tabToIndentListener} from 'indent-textarea';
 
-delegate(document.body, 'textarea', 'keydown', eventHandler);
+delegate(document.body, 'textarea', 'keydown', tabToIndentListener);
 ```
 
 # Related

--- a/tests/indent.js
+++ b/tests/indent.js
@@ -1,13 +1,13 @@
 import test from 'tape';
-import {indent} from '../index.js';
+import {indentField} from '../index.js';
 import {getField, getState} from './_tools.js';
 
 test('insert tab in empty field', t => {
 	const textarea = getField();
 	t.equal(getState(textarea), '|');
-	indent(textarea);
+	indentField(textarea);
 	t.equal(getState(textarea), '\t|');
-	indent(textarea);
+	indentField(textarea);
 	t.equal(getState(textarea), '\t\t|');
 	t.end();
 });
@@ -15,7 +15,7 @@ test('insert tab in empty field', t => {
 test('insert tab in filled field (start)', t => {
 	const textarea = getField('|hello');
 	t.equal(getState(textarea), '|hello');
-	indent(textarea);
+	indentField(textarea);
 	t.equal(getState(textarea), '\t|hello');
 	t.end();
 });
@@ -23,7 +23,7 @@ test('insert tab in filled field (start)', t => {
 test('insert tab in filled field (end)', t => {
 	const textarea = getField('hello|');
 	t.equal(getState(textarea), 'hello|');
-	indent(textarea);
+	indentField(textarea);
 	t.equal(getState(textarea), 'hello\t|');
 	t.end();
 });
@@ -31,7 +31,7 @@ test('insert tab in filled field (end)', t => {
 test('insert tab and replace selection', t => {
 	const textarea = getField('he{ll}o');
 	t.equal(getState(textarea), 'he{ll}o');
-	indent(textarea);
+	indentField(textarea);
 	t.equal(getState(textarea), 'he\t|o');
 	t.end();
 });
@@ -39,9 +39,9 @@ test('insert tab and replace selection', t => {
 test('indent every selected line', t => {
 	const textarea = getField('{a\nb\nc}');
 	t.equal(getState(textarea), '{a\nb\nc}');
-	indent(textarea);
+	indentField(textarea);
 	t.equal(getState(textarea), '\t{a\n\tb\n\tc}');
-	indent(textarea);
+	indentField(textarea);
 	t.equal(getState(textarea), '\t\t{a\n\t\tb\n\t\tc}');
 	t.end();
 });
@@ -49,7 +49,7 @@ test('indent every selected line', t => {
 test('indent every line counting from the linebreak itself', t => {
 	const textarea = getField('a{\nb\nc}');
 	t.equal(getState(textarea), 'a{\nb\nc}');
-	indent(textarea);
+	indentField(textarea);
 	t.equal(getState(textarea), '\ta{\n\tb\n\tc}');
 	t.end();
 });
@@ -57,7 +57,7 @@ test('indent every line counting from the linebreak itself', t => {
 test('indent every line stopping before the last linebreak', t => {
 	const textarea = getField('a{\nb\n}c');
 	t.equal(getState(textarea), 'a{\nb\n}c');
-	indent(textarea);
+	indentField(textarea);
 	t.equal(getState(textarea), '\ta{\n\tb\n}c');
 	t.end();
 });
@@ -65,7 +65,7 @@ test('indent every line stopping before the last linebreak', t => {
 test('indent every line (following both the previous rules)', t => {
 	const textarea = getField('a{\n}b\nc');
 	t.equal(getState(textarea), 'a{\n}b\nc');
-	indent(textarea);
+	indentField(textarea);
 	t.equal(getState(textarea), '\ta{\n}b\nc');
 	t.end();
 });

--- a/tests/unindent.js
+++ b/tests/unindent.js
@@ -1,11 +1,11 @@
 import test from 'tape';
-import {unindent} from '../index.js';
+import {unindentField} from '../index.js';
 import {getField, getState} from './_tools.js';
 
 test('unindent empty field (noop)', t => {
 	const textarea = getField();
 	t.equal(getState(textarea), '|');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '|');
 	t.end();
 });
@@ -13,7 +13,7 @@ test('unindent empty field (noop)', t => {
 test('unindent filled field (start)', t => {
 	const textarea = getField('\t|hello');
 	t.equal(getState(textarea), '\t|hello');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '|hello');
 	t.end();
 });
@@ -21,7 +21,7 @@ test('unindent filled field (start)', t => {
 test('unindent filled field (middle)', t => {
 	const textarea = getField('\thel|lo');
 	t.equal(getState(textarea), '\thel|lo');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), 'hel|lo');
 	t.end();
 });
@@ -29,7 +29,7 @@ test('unindent filled field (middle)', t => {
 test('unindent filled field (between tabs)', t => {
 	const textarea = getField('\t|\thello');
 	t.equal(getState(textarea), '\t|\thello');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '|\thello');
 	t.end();
 });
@@ -37,7 +37,7 @@ test('unindent filled field (between tabs)', t => {
 test('unindent filled field (end)', t => {
 	const textarea = getField('\thello|');
 	t.equal(getState(textarea), '\thello|');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), 'hello|');
 	t.end();
 });
@@ -45,7 +45,7 @@ test('unindent filled field (end)', t => {
 test('unindent line with selection without replacing it', t => {
 	const textarea = getField('\the{ll}o');
 	t.equal(getState(textarea), '\the{ll}o');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), 'he{ll}o');
 	t.end();
 });
@@ -53,9 +53,9 @@ test('unindent line with selection without replacing it', t => {
 test('unindent every selected line', t => {
 	const textarea = getField('{\t\ta\nb\n\t\tc}');
 	t.equal(getState(textarea), '{\t\ta\nb\n\t\tc}');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '{\ta\nb\n\tc}');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '{a\nb\nc}');
 	t.end();
 });
@@ -63,7 +63,7 @@ test('unindent every selected line', t => {
 test('unindent every line counting from the linebreak itself', t => {
 	const textarea = getField('\ta{\n\tb\n\tc}');
 	t.equal(getState(textarea), '\ta{\n\tb\n\tc}');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), 'a{\nb\nc}');
 	t.end();
 });
@@ -71,7 +71,7 @@ test('unindent every line counting from the linebreak itself', t => {
 test('unindent every line stopping before the last linebreak', t => {
 	const textarea = getField('\ta{\n\tb\n}c');
 	t.equal(getState(textarea), '\ta{\n\tb\n}c');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), 'a{\nb\n}c');
 	t.end();
 });
@@ -79,7 +79,7 @@ test('unindent every line stopping before the last linebreak', t => {
 test('unindent every line (following both the previous rules)', t => {
 	const textarea = getField('\ta{\n}b\nc');
 	t.equal(getState(textarea), '\ta{\n}b\nc');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), 'a{\n}b\nc');
 	t.end();
 });
@@ -87,22 +87,22 @@ test('unindent every line (following both the previous rules)', t => {
 test('preserve cursor position when deindenting after it', t => {
 	const textarea = getField('\t\n|\t');
 	t.equal(getState(textarea), '\t\n|\t');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '\t\n|');
-	unindent(textarea);
+	unindentField(textarea);
 	t.end();
 });
 
 test('ignore whitespace on other lines', t => {
 	let textarea = getField('\t\n\t|\t\n\t');
 	t.equal(getState(textarea), '\t\n\t|\t\n\t');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '\t\n|\t\n\t');
-	unindent(textarea);
+	unindentField(textarea);
 
 	textarea = getField('\t\t\t\t\n\t|\n\t');
 	t.equal(getState(textarea), '\t\t\t\t\n\t|\n\t');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '\t\t\t\t\n|\n\t');
 
 	// TODO: Fix this test, it used to work
@@ -111,7 +111,7 @@ test('ignore whitespace on other lines', t => {
 
 	textarea = getField('     \t\n  |\n\t');
 	t.equal(getState(textarea), '     \t\n  |\n\t');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '     \t\n|\n\t');
 
 	t.end();
@@ -120,7 +120,7 @@ test('ignore whitespace on other lines', t => {
 test.skip('ignore trailing whitespace', t => {
 	const textarea = getField('a\t\t|');
 	t.equal(getState(textarea), 'a\t\t|');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), 'a\t\t|');
 	t.end();
 });
@@ -128,9 +128,9 @@ test.skip('ignore trailing whitespace', t => {
 test('unindent 2 spaces', t => {
 	const textarea = getField('    hel|lo');
 	t.equal(getState(textarea), '    hel|lo');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '  hel|lo');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), 'hel|lo');
 	t.end();
 });
@@ -138,9 +138,9 @@ test('unindent 2 spaces', t => {
 test('unindent mixed spaces and tabs', t => {
 	const textarea = getField('  \t  hel|lo');
 	t.equal(getState(textarea), '  \t  hel|lo');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '\t  hel|lo');
-	unindent(textarea);
+	unindentField(textarea);
 	t.equal(getState(textarea), '  hel|lo');
 	t.end();
 });


### PR DESCRIPTION
The previous names weren't standalone: `watch` didn't mean much, so it required `import * as indentation` to make some sense (`indentation.watch`)

`enableTabToIndent` makes much more sense and can be imported independently: `import {enableTabToIndent}`

The old API remains exported but deprecated.

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><code>watch</code>
	<td><code>enableTabToIndent</code>
<tr>
	<td><code>indent</code>
	<td><code>indentSelection</code>
<tr>
	<td><code>unindent</code>
	<td><code>unindentSelection</code>
<tr>
	<td><code>eventListener</code>
	<td><code>tabToIndentListener</code>
</table>